### PR TITLE
fix-comparable-bug

### DIFF
--- a/src/main/java/com/github/hcsp/polymorphism/User.java
+++ b/src/main/java/com/github/hcsp/polymorphism/User.java
@@ -6,10 +6,14 @@ import java.util.Objects;
 import java.util.TreeSet;
 
 public class User implements Comparable<User> {
-    /** 用户ID，数据库主键，全局唯一 */
+    /**
+     * 用户ID，数据库主键，全局唯一
+     */
     private final Integer id;
 
-    /** 用户名 */
+    /**
+     * 用户名
+     */
     private final String name;
 
     public User(Integer id, String name) {
@@ -44,10 +48,16 @@ public class User implements Comparable<User> {
         return id != null ? id.hashCode() : 0;
     }
 
-    /** 老板说让我按照用户名排序 */
+    /**
+     * 老板说让我按照用户名排序
+     */
     @Override
     public int compareTo(User o) {
+        if (this.name.equals(o.name)) {
+            return id.compareTo(o.id);
+        }
         return name.compareTo(o.name);
+
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
因为compareto 将同名不同ID的判断为相等了，在list列表中是不能存在相等的数据，所以将其中一项丢弃了