### PR TITLE
修复comparable实现中的bug

### DIFF
--- a/src/main/java/com/github/hcsp/polymorphism/User.java
+++ b/src/main/java/com/github/hcsp/polymorphism/User.java
@@ -47,7 +47,8 @@ public class User implements Comparable<User> {
     /** 老板说让我按照用户名排序 */
     @Override
     public int compareTo(User o) {
-        return name.compareTo(o.name);
+        final int result = name.compareTo(o.name);
+        return result != 0 ? result : getId().compareTo(o.getId());
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
按照用户名排序，当用户名重复，compareTo方法返回值为0  就会导致在输出treeSet.size()时的值比少1，应该重写compareTo方法时，判断一下返回值是否为0，如果为0，应该返回id的排序 